### PR TITLE
fix: defer tree load until auth resolves

### DIFF
--- a/frontend/src/components/graph/TaxonomyGraph.jsx
+++ b/frontend/src/components/graph/TaxonomyGraph.jsx
@@ -15,7 +15,7 @@ import FocusHUD from './FocusHUD';
 import { filterEntries, computeFacets, countActiveFilters, emptyFilters } from '../../lib/treeFilters';
 import useIsMobile from '../../hooks/useIsMobile';
 
-const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser }, ref) {
+const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser, authLoading }, ref) {
   const canvasRef = useRef(null);
   const starFieldRef = useRef(null);
   const initialFitDone = useRef(false);
@@ -89,8 +89,11 @@ const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser }, ref) {
     refetch: () => fetchTreeData({ refresh: true }),
   }), [fetchTreeData]);
 
-  // Initial load
+  // Initial load — wait for auth to resolve before fetching so we know
+  // whether to expand the user's paths or use guest defaults (avoids
+  // double-fetch and camera re-positioning race condition)
   useEffect(() => {
+    if (authLoading) return;
     let cancelled = false;
     fetchTreeData()
       .then(({ entries: e, fictionalEntries: fe }) => {
@@ -133,7 +136,7 @@ const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser }, ref) {
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [currentUser?.id, fetchTreeData]);
+  }, [authLoading, currentUser?.id, fetchTreeData]);
 
   // Auto-focus logged-in user
   useEffect(() => {

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -5,7 +5,7 @@ import TaxonomyGraph from '../components/graph/TaxonomyGraph';
 import SEOHead from '../components/SEOHead';
 
 export default function HomePage({ treeRefetchRef }) {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const treeRef = useRef(null);
 
   useEffect(() => {
@@ -51,7 +51,7 @@ export default function HomePage({ treeRefetchRef }) {
           },
         ]}
       />
-      <TaxonomyGraph ref={treeRef} currentUser={user} />
+      <TaxonomyGraph ref={treeRef} currentUser={user} authLoading={authLoading} />
 
       <div style={{
         position: 'fixed',


### PR DESCRIPTION
## Summary
- Pass `authLoading` from `useAuth()` to `TaxonomyGraph`
- Skip initial tree fetch until auth resolves (`if (authLoading) return`)
- Prevents double-fetch and camera positioning race condition where camera aimed at stale guest-view center after tree re-expanded with user-only paths

## Root cause
Auth is async: `currentUser` starts as `null`, so the initial load effect ran twice — first as guest (depth=2) positioning camera + setting `initialFitDone=true`, then re-running with user paths but skipping camera since `initialFitDone` was already true.

## Test plan
- [ ] Logged in: camera should point at user's node on load
- [ ] Guest: camera should show depth=2 overview
- [ ] No visible delay increase from waiting for auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)