### PR TITLE
feat: add trait sort order with drag-and-drop

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -438,6 +438,7 @@ class VtuberTrait(db.Model):
     breed_id = db.Column(db.Integer, db.ForeignKey('breeds.id',
                          ondelete='SET NULL'))
     trait_note = db.Column(db.Text)
+    sort_order = db.Column(db.Integer, nullable=False, default=0)
     created_at = db.Column(db.DateTime(timezone=True), nullable=False,
                            default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime(timezone=True), nullable=False,
@@ -481,6 +482,7 @@ class VtuberTrait(db.Model):
             'breed_name': breed_display,
             'breed_id': self.breed_id,
             'trait_note': self.trait_note,
+            'sort_order': self.sort_order,
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat(),
         }

--- a/backend/app/routes/taxonomy.py
+++ b/backend/app/routes/taxonomy.py
@@ -208,6 +208,7 @@ def get_taxonomy_tree():
             'breed_name_zh': breed_name_zh,
             'breed_name_en': breed_name_en,
             'path_zh': path_zh,
+            'sort_order': trait.sort_order,
         })
 
     # Persist rebuilt path_zh to DB so future reads are instant
@@ -291,6 +292,7 @@ def get_fictional_tree():
             'fictional_name_zh': fictional.name_zh or fictional.name,
             'origin': fictional.origin,
             'sub_origin': fictional.sub_origin,
+            'sort_order': trait.sort_order,
         })
 
     result = {'entries': entries}

--- a/backend/app/routes/traits.py
+++ b/backend/app/routes/traits.py
@@ -5,6 +5,7 @@ from ..cache import invalidate_tree_cache, invalidate_fictional_tree_cache
 from ..extensions import db
 from ..models import Breed, FictionalSpecies, SpeciesCache, VtuberTrait
 from ..services.gbif import get_species
+from sqlalchemy import func
 
 traits_bp = Blueprint('traits', __name__)
 
@@ -92,6 +93,7 @@ def create_trait():
                     replaced_info = {
                         'replaced_trait_id': et.id,
                         'replaced_display_name': et.computed_display_name(),
+                        'replaced_sort_order': et.sort_order,
                     }
                     db.session.delete(et)
                     break
@@ -124,6 +126,14 @@ def create_trait():
         if taxon_id and not _breed_matches_taxon(breed, taxon_id):
             return jsonify({'error': 'Breed does not belong to this species'}), 400
 
+    # Determine sort_order for new trait
+    if replaced_info:
+        new_sort_order = replaced_info['replaced_sort_order']
+    else:
+        max_order = db.session.query(func.max(VtuberTrait.sort_order)).filter_by(
+            user_id=g.current_user_id).scalar()
+        new_sort_order = (max_order + 1) if max_order is not None else 0
+
     trait = VtuberTrait(
         user_id=g.current_user_id,
         taxon_id=taxon_id,
@@ -131,6 +141,7 @@ def create_trait():
         breed_id=breed_id,
         breed_name=data.get('breed_name') if not breed_id else None,
         trait_note=data.get('trait_note'),
+        sort_order=new_sort_order,
     )
     db.session.add(trait)
     db.session.commit()
@@ -151,8 +162,33 @@ def list_traits():
     if not user_id:
         return jsonify({'error': 'user_id query parameter required'}), 400
 
-    traits = VtuberTrait.query.filter_by(user_id=user_id).all()
+    traits = VtuberTrait.query.filter_by(user_id=user_id).order_by(
+        VtuberTrait.sort_order.asc()).all()
     return jsonify({'traits': [t.to_dict() for t in traits]})
+
+
+@traits_bp.route('/reorder', methods=['PUT'])
+@login_required
+def reorder_traits():
+    data = request.get_json() or {}
+    ordered_ids = data.get('trait_ids', [])
+
+    traits = VtuberTrait.query.filter_by(user_id=g.current_user_id).all()
+    trait_map = {str(t.id): t for t in traits}
+
+    if len(ordered_ids) != len(traits):
+        return jsonify({'error': 'trait_ids count mismatch'}), 400
+
+    for i, tid in enumerate(ordered_ids):
+        trait = trait_map.get(str(tid))
+        if not trait:
+            return jsonify({'error': f'Trait {tid} not found'}), 400
+        trait.sort_order = i
+
+    db.session.commit()
+    invalidate_tree_cache()
+    invalidate_fictional_tree_cache()
+    return jsonify({'message': 'ok'})
 
 
 @traits_bp.route('/<trait_id>', methods=['PATCH'])

--- a/frontend/src/components/graph/TaxonomyGraph.jsx
+++ b/frontend/src/components/graph/TaxonomyGraph.jsx
@@ -629,8 +629,11 @@ const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser }, ref) {
     setTimeout(() => {
       if (currentUser) {
         // Logged-in: go directly to user's node (tree only expands user's paths)
-        const userEntry = entries?.find(e => e.user_id === currentUser.id)
-          || fictionalEntries?.find(e => e.user_id === currentUser.id);
+        const allUserEntries = [
+          ...(entries || []).filter(e => e.user_id === currentUser.id),
+          ...(fictionalEntries || []).filter(e => e.user_id === currentUser.id),
+        ].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+        const userEntry = allUserEntries[0];
         if (userEntry) {
           const userPathKey = entryToVtuberPathKey(userEntry, breedPaths);
           const userNode = nodes.find(n => n.data._pathKey === userPathKey);
@@ -925,7 +928,7 @@ const TaxonomyGraph = forwardRef(function TaxonomyGraph({ currentUser }, ref) {
     if (!selectedVtuber) return [];
     const real = entries ? entries.filter(e => e.user_id === selectedVtuber.user_id) : [];
     const fict = fictionalEntries ? fictionalEntries.filter(e => e.user_id === selectedVtuber.user_id) : [];
-    return [...real, ...fict];
+    return [...real, ...fict].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
   }, [selectedVtuber?.user_id, entries, fictionalEntries]);
 
   // Switch entry from detail panel trait tabs — update panel + focus + camera

--- a/frontend/src/components/settings/SettingsFictional.jsx
+++ b/frontend/src/components/settings/SettingsFictional.jsx
@@ -30,12 +30,16 @@ function RemoveButton({ onClick }) {
   );
 }
 
-export default function SettingsFictional() {
+export default function SettingsFictional({ onReorder }) {
   const { user } = useAuth();
   const { addToast } = useToast();
   const [traits, setTraits] = useState([]);
+  const [allTraits, setAllTraits] = useState([]);
   const [showPicker, setShowPicker] = useState(false);
   const pickerRef = useRef(null);
+  const [dragIdx, setDragIdx] = useState(null);
+  const [dragOverIdx, setDragOverIdx] = useState(null);
+  const isTouch = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
   useEffect(() => {
     if (user) loadTraits();
@@ -44,11 +48,39 @@ export default function SettingsFictional() {
   async function loadTraits() {
     try {
       const data = await api.getTraits(user.id);
-      // Only fictional traits (fictional_species_id is set)
-      setTraits((data.traits || []).filter(t => t.fictional_species_id));
+      const all = data.traits || [];
+      setAllTraits(all);
+      setTraits(all.filter(t => t.fictional_species_id));
     } catch (err) {
       console.error(err);
     }
+  }
+
+  async function applyReorder(newFictionalTraits) {
+    const prevTraits = traits;
+    const prevAll = allTraits;
+    const realTraits = allTraits.filter(t => !t.fictional_species_id);
+    const newAll = [...realTraits, ...newFictionalTraits];
+    const orderedIds = newAll.map(t => t.id);
+
+    setTraits(newFictionalTraits);
+    setAllTraits(newAll);
+    try {
+      await api.reorderTraits(orderedIds);
+      onReorder?.();
+    } catch (err) {
+      setTraits(prevTraits);
+      setAllTraits(prevAll);
+      addToast('排序更新失敗', { type: 'error' });
+    }
+  }
+
+  function moveTraitBy(index, delta) {
+    const newIdx = index + delta;
+    if (newIdx < 0 || newIdx >= traits.length) return;
+    const newTraits = [...traits];
+    [newTraits[index], newTraits[newIdx]] = [newTraits[newIdx], newTraits[index]];
+    applyReorder(newTraits);
   }
 
   const existingFictionalIds = useMemo(
@@ -107,44 +139,97 @@ export default function SettingsFictional() {
         <p style={{ color: 'rgba(255,255,255,0.4)', marginBottom: '16px' }}>尚未新增虛構物種特徵</p>
       ) : (
         <div style={{ marginBottom: '16px' }}>
-          {traits.map(trait => (
-            <div key={trait.id} style={{
-              display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
-              padding: '12px 16px',
-              borderRadius: '8px',
-              border: '1px solid rgba(255,255,255,0.06)',
-              background: 'rgba(255,255,255,0.02)',
-              marginBottom: '8px',
-            }}>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <span style={{ fontWeight: 700, color: '#e2e8f0' }}>
-                  {trait.fictional?.name_zh || trait.fictional?.name || trait.display_name}
-                </span>
-                {trait.fictional?.name_zh && trait.fictional?.name && trait.fictional.name_zh !== trait.fictional.name && (
-                  <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.85em', marginLeft: '6px' }}>
-                    ({trait.fictional.name})
+          {traits.map((trait, idx) => {
+            const showSortControls = traits.length >= 2;
+            return (
+              <div
+                key={trait.id}
+                draggable={!isTouch && showSortControls}
+                onDragStart={() => setDragIdx(idx)}
+                onDragEnd={() => { setDragIdx(null); setDragOverIdx(null); }}
+                onDragOver={(e) => { e.preventDefault(); setDragOverIdx(idx); }}
+                onDrop={() => {
+                  if (dragIdx !== null && dragIdx !== idx) {
+                    const newTraits = [...traits];
+                    const [moved] = newTraits.splice(dragIdx, 1);
+                    newTraits.splice(idx, 0, moved);
+                    applyReorder(newTraits);
+                  }
+                  setDragIdx(null);
+                  setDragOverIdx(null);
+                }}
+                style={{
+                  display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+                  padding: '12px 16px',
+                  borderRadius: '8px',
+                  border: dragOverIdx === idx && dragIdx !== null && dragIdx !== idx
+                    ? '1px solid rgba(56,189,248,0.5)'
+                    : '1px solid rgba(255,255,255,0.06)',
+                  background: dragIdx === idx ? 'rgba(56,189,248,0.08)' : 'rgba(255,255,255,0.02)',
+                  marginBottom: '8px',
+                  opacity: dragIdx === idx ? 0.5 : 1,
+                  cursor: !isTouch && showSortControls ? 'grab' : 'default',
+                }}
+              >
+                {showSortControls && (
+                  isTouch ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginRight: '8px', flexShrink: 0 }}>
+                      <button
+                        onClick={() => moveTraitBy(idx, -1)}
+                        disabled={idx === 0}
+                        style={{
+                          padding: '2px 6px', background: 'transparent', border: '1px solid rgba(255,255,255,0.1)',
+                          borderRadius: '3px', color: idx === 0 ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.5)',
+                          cursor: idx === 0 ? 'default' : 'pointer', fontSize: '0.7em', lineHeight: 1,
+                        }}
+                      >▲</button>
+                      <button
+                        onClick={() => moveTraitBy(idx, 1)}
+                        disabled={idx === traits.length - 1}
+                        style={{
+                          padding: '2px 6px', background: 'transparent', border: '1px solid rgba(255,255,255,0.1)',
+                          borderRadius: '3px', color: idx === traits.length - 1 ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.5)',
+                          cursor: idx === traits.length - 1 ? 'default' : 'pointer', fontSize: '0.7em', lineHeight: 1,
+                        }}
+                      >▼</button>
+                    </div>
+                  ) : (
+                    <div style={{
+                      marginRight: '8px', color: 'rgba(255,255,255,0.2)', fontSize: '1.1em',
+                      display: 'flex', alignItems: 'center', flexShrink: 0, userSelect: 'none',
+                    }}>⠿</div>
+                  )
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ fontWeight: 700, color: '#e2e8f0' }}>
+                    {trait.fictional?.name_zh || trait.fictional?.name || trait.display_name}
                   </span>
-                )}
-                {trait.fictional?.origin && (
-                  <span style={{
-                    marginLeft: '8px', display: 'inline-block',
-                    padding: '1px 6px', borderRadius: '3px', fontSize: '0.75em',
-                    background: 'rgba(168,85,247,0.15)', color: '#a855f7',
-                    border: '1px solid rgba(168,85,247,0.25)',
-                  }}>
-                    {trait.fictional.origin}
-                    {trait.fictional.sub_origin && ` / ${trait.fictional.sub_origin}`}
-                  </span>
-                )}
-                {trait.trait_note && (
-                  <div style={{ fontSize: '0.8em', color: 'rgba(255,255,255,0.3)', marginTop: '2px' }}>
-                    {trait.trait_note}
-                  </div>
-                )}
+                  {trait.fictional?.name_zh && trait.fictional?.name && trait.fictional.name_zh !== trait.fictional.name && (
+                    <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.85em', marginLeft: '6px' }}>
+                      ({trait.fictional.name})
+                    </span>
+                  )}
+                  {trait.fictional?.origin && (
+                    <span style={{
+                      marginLeft: '8px', display: 'inline-block',
+                      padding: '1px 6px', borderRadius: '3px', fontSize: '0.75em',
+                      background: 'rgba(168,85,247,0.15)', color: '#a855f7',
+                      border: '1px solid rgba(168,85,247,0.25)',
+                    }}>
+                      {trait.fictional.origin}
+                      {trait.fictional.sub_origin && ` / ${trait.fictional.sub_origin}`}
+                    </span>
+                  )}
+                  {trait.trait_note && (
+                    <div style={{ fontSize: '0.8em', color: 'rgba(255,255,255,0.3)', marginTop: '2px' }}>
+                      {trait.trait_note}
+                    </div>
+                  )}
+                </div>
+                <RemoveButton onClick={() => handleDelete(trait.id)} />
               </div>
-              <RemoveButton onClick={() => handleDelete(trait.id)} />
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/components/settings/SettingsRealSpecies.jsx
+++ b/frontend/src/components/settings/SettingsRealSpecies.jsx
@@ -84,12 +84,16 @@ function RemoveButton({ onClick }) {
 }
 
 
-export default function SettingsRealSpecies() {
+export default function SettingsRealSpecies({ onReorder }) {
   const { user } = useAuth();
   const { addToast } = useToast();
   const [traits, setTraits] = useState([]);
+  const [allTraits, setAllTraits] = useState([]); // all traits including fictional, for reorder API
   const [showSearch, setShowSearch] = useState(false);
   const searchRef = useRef(null);
+  const [dragIdx, setDragIdx] = useState(null);
+  const [dragOverIdx, setDragOverIdx] = useState(null);
+  const isTouch = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
   useEffect(() => {
     if (user) loadTraits();
@@ -104,11 +108,40 @@ export default function SettingsRealSpecies() {
   async function loadTraits() {
     try {
       const data = await api.getTraits(user.id);
-      // Only real species traits (taxon_id is set)
-      setTraits((data.traits || []).filter(t => t.taxon_id));
+      const all = data.traits || [];
+      setAllTraits(all);
+      setTraits(all.filter(t => t.taxon_id));
     } catch (err) {
       console.error(err);
     }
+  }
+
+  async function applyReorder(newRealTraits) {
+    const prevTraits = traits;
+    const prevAll = allTraits;
+    // Build new full list: replace real traits portion while keeping fictional order
+    const fictionalTraits = allTraits.filter(t => !t.taxon_id);
+    const newAll = [...newRealTraits, ...fictionalTraits];
+    const orderedIds = newAll.map(t => t.id);
+
+    setTraits(newRealTraits);
+    setAllTraits(newAll);
+    try {
+      await api.reorderTraits(orderedIds);
+      onReorder?.();
+    } catch (err) {
+      setTraits(prevTraits);
+      setAllTraits(prevAll);
+      addToast('排序更新失敗', { type: 'error' });
+    }
+  }
+
+  function moveTraitBy(index, delta) {
+    const newIdx = index + delta;
+    if (newIdx < 0 || newIdx >= traits.length) return;
+    const newTraits = [...traits];
+    [newTraits[index], newTraits[newIdx]] = [newTraits[newIdx], newTraits[index]];
+    applyReorder(newTraits);
   }
 
   async function handleAddTrait(species) {
@@ -171,19 +204,71 @@ export default function SettingsRealSpecies() {
         <p style={{ color: 'rgba(255,255,255,0.4)', marginBottom: '16px' }}>尚未新增真實物種特徵</p>
       ) : (
         <div style={{ marginBottom: '16px' }}>
-          {traits.map(trait => {
+          {traits.map((trait, idx) => {
             const displayName = trait.species?.common_name_zh || displayScientificName(trait.species) || trait.display_name;
             const rank = (trait.species?.taxon_rank || '').toUpperCase() || null;
+            const showSortControls = traits.length >= 2;
 
             return (
-              <div key={trait.id} style={{
-                padding: '12px 16px',
-                borderRadius: '8px',
-                border: '1px solid rgba(255,255,255,0.06)',
-                background: 'rgba(255,255,255,0.02)',
-                marginBottom: '8px',
-                display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
-              }}>
+              <div
+                key={trait.id}
+                draggable={!isTouch && showSortControls}
+                onDragStart={() => setDragIdx(idx)}
+                onDragEnd={() => { setDragIdx(null); setDragOverIdx(null); }}
+                onDragOver={(e) => { e.preventDefault(); setDragOverIdx(idx); }}
+                onDrop={() => {
+                  if (dragIdx !== null && dragIdx !== idx) {
+                    const newTraits = [...traits];
+                    const [moved] = newTraits.splice(dragIdx, 1);
+                    newTraits.splice(idx, 0, moved);
+                    applyReorder(newTraits);
+                  }
+                  setDragIdx(null);
+                  setDragOverIdx(null);
+                }}
+                style={{
+                  padding: '12px 16px',
+                  borderRadius: '8px',
+                  border: dragOverIdx === idx && dragIdx !== null && dragIdx !== idx
+                    ? '1px solid rgba(56,189,248,0.5)'
+                    : '1px solid rgba(255,255,255,0.06)',
+                  background: dragIdx === idx ? 'rgba(56,189,248,0.08)' : 'rgba(255,255,255,0.02)',
+                  marginBottom: '8px',
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+                  opacity: dragIdx === idx ? 0.5 : 1,
+                  cursor: !isTouch && showSortControls ? 'grab' : 'default',
+                }}
+              >
+                {/* Sort controls */}
+                {showSortControls && (
+                  isTouch ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginRight: '8px', flexShrink: 0 }}>
+                      <button
+                        onClick={() => moveTraitBy(idx, -1)}
+                        disabled={idx === 0}
+                        style={{
+                          padding: '2px 6px', background: 'transparent', border: '1px solid rgba(255,255,255,0.1)',
+                          borderRadius: '3px', color: idx === 0 ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.5)',
+                          cursor: idx === 0 ? 'default' : 'pointer', fontSize: '0.7em', lineHeight: 1,
+                        }}
+                      >▲</button>
+                      <button
+                        onClick={() => moveTraitBy(idx, 1)}
+                        disabled={idx === traits.length - 1}
+                        style={{
+                          padding: '2px 6px', background: 'transparent', border: '1px solid rgba(255,255,255,0.1)',
+                          borderRadius: '3px', color: idx === traits.length - 1 ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.5)',
+                          cursor: idx === traits.length - 1 ? 'default' : 'pointer', fontSize: '0.7em', lineHeight: 1,
+                        }}
+                      >▼</button>
+                    </div>
+                  ) : (
+                    <div style={{
+                      marginRight: '8px', color: 'rgba(255,255,255,0.2)', fontSize: '1.1em',
+                      display: 'flex', alignItems: 'center', flexShrink: 0, userSelect: 'none',
+                    }}>⠿</div>
+                  )
+                )}
                 <div style={{ flex: 1, minWidth: 0 }}>
                   {trait.species && <TaxonomyPath species={trait.species} />}
                   <div style={{ display: 'flex', alignItems: 'baseline', flexWrap: 'wrap', gap: '6px', marginTop: trait.species ? '4px' : 0 }}>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -186,6 +186,9 @@ export const api = {
     method: 'PATCH', body: JSON.stringify(body),
   }),
   deleteTrait: (id) => apiFetch(`/traits/${id}`, { method: 'DELETE' }),
+  reorderTraits: (traitIds) => apiFetch('/traits/reorder', {
+    method: 'PUT', body: JSON.stringify({ trait_ids: traitIds }),
+  }),
 
   // Taxonomy
   getTaxonomyTree: (qs = '') => apiFetch(`/taxonomy/tree${qs}`),

--- a/frontend/src/pages/CharacterPage.jsx
+++ b/frontend/src/pages/CharacterPage.jsx
@@ -21,6 +21,7 @@ export default function CharacterPage() {
   const { user, loading } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const [oauthAccounts, setOauthAccounts] = useState([]);
+  const [traitVersion, setTraitVersion] = useState(0);
 
   const activeTab = searchParams.get('tab') || 'species';
 
@@ -47,7 +48,7 @@ export default function CharacterPage() {
     } catch (err) {
       console.error('Failed to load preview data:', err);
     }
-  }, [user?.id]);
+  }, [user?.id, traitVersion]);
 
   function setActiveTab(tab) {
     if (tab === 'species') {
@@ -154,10 +155,10 @@ export default function CharacterPage() {
       {activeTab === 'species' && (
         <>
           <div style={{ marginBottom: '24px' }}>
-            <SettingsRealSpecies />
+            <SettingsRealSpecies onReorder={() => setTraitVersion(v => v + 1)} />
           </div>
           <div style={{ marginBottom: '24px' }}>
-            <SettingsFictional />
+            <SettingsFictional onReorder={() => setTraitVersion(v => v + 1)} />
           </div>
         </>
       )}

--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -169,6 +169,7 @@ CREATE TABLE vtuber_traits (
     breed_name TEXT,               -- 品種名稱（legacy 自由文字，優先使用 breed_id）
     breed_id   INTEGER REFERENCES breeds(id) ON DELETE SET NULL,
     trait_note TEXT,
+    sort_order INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     CHECK (taxon_id IS NOT NULL OR fictional_species_id IS NOT NULL)
@@ -178,6 +179,7 @@ CREATE INDEX idx_vtuber_traits_user_id ON vtuber_traits(user_id);
 CREATE INDEX idx_vtuber_traits_taxon_id ON vtuber_traits(taxon_id);
 CREATE INDEX idx_vtuber_traits_fictional_species_id ON vtuber_traits(fictional_species_id);
 CREATE INDEX idx_vtuber_traits_breed_id ON vtuber_traits(breed_id);
+CREATE INDEX idx_vtuber_traits_sort_order ON vtuber_traits(user_id, sort_order);
 
 -- 同一角色不能重複標註同一現實物種
 CREATE UNIQUE INDEX idx_vtuber_traits_user_taxon

--- a/supabase/migrations/20260308_add_trait_sort_order.sql
+++ b/supabase/migrations/20260308_add_trait_sort_order.sql
@@ -1,0 +1,16 @@
+-- Add sort_order column to vtuber_traits for user-defined trait ordering
+-- Backfill existing data with order based on created_at
+
+-- staging
+ALTER TABLE staging.vtuber_traits ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+UPDATE staging.vtuber_traits t SET sort_order = sub.rn - 1
+FROM (SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at) AS rn FROM staging.vtuber_traits) sub
+WHERE t.id = sub.id;
+CREATE INDEX IF NOT EXISTS idx_vtuber_traits_sort_order ON staging.vtuber_traits(user_id, sort_order);
+
+-- public (same)
+ALTER TABLE public.vtuber_traits ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+UPDATE public.vtuber_traits t SET sort_order = sub.rn - 1
+FROM (SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at) AS rn FROM public.vtuber_traits) sub
+WHERE t.id = sub.id;
+CREATE INDEX IF NOT EXISTS idx_vtuber_traits_sort_order ON public.vtuber_traits(user_id, sort_order);


### PR DESCRIPTION
## Summary
- Add `sort_order` column to `vtuber_traits` with DB migration for staging + public
- Backend: `PUT /traits/reorder` endpoint, auto-assign sort_order on create, sort in list/tree APIs
- Frontend: drag handles (desktop) + arrow buttons (touch) for reordering traits
- Camera focus and detail panel tabs respect sort_order

## Test plan
- [ ] Run migration on staging DB
- [ ] Verify trait list returns in sort_order
- [ ] Test drag reorder on desktop, arrow buttons on mobile
- [ ] Verify preview panel tabs update after reorder
- [ ] Verify camera focuses on sort_order=0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)